### PR TITLE
Fix link to authoritative Volto training

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-A training on how to create your own website using Volto is available as part of the Plone training at [https://training.plone.org/5/volto/index.html](https://training.plone.org/5/volto/index.html).
+A training on how to create your own website using Volto is available as part of the Plone training at [https://training.plone.org/voltohandson/index.html](https://training.plone.org/voltohandson/index.html).
 
 ## Installation
 


### PR DESCRIPTION
I'm not sure whether the link should be to https://training.plone.org/voltohandson/index.html or the archived URL (when live) https://2022.training.plone.org/volto/index.html, so I made my best guess.

Refs:
- https://github.com/plone/training/issues/740
- https://github.com/plone/training/issues/672